### PR TITLE
Next.js Server-Side-Rendering 준비하기

### DIFF
--- a/prepare/front/pages/index.js
+++ b/prepare/front/pages/index.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'; // next는 이 구문이 필요없다(써도 상관은 없다)
 import { useDispatch, useSelector } from 'react-redux';
+import { END } from 'redux-saga';
 
 import AppLayout from '../components/AppLayout';
 import PostForm from '../components/PostForm';
@@ -7,6 +8,7 @@ import PostCard from '../components/PostCard';
 
 import { LOAD_POSTS_REQUEST } from '../reducers/post';
 import { LOAD_MY_INFO_REQUEST } from '../reducers/user';
+import wrapper from '../store/configureStore';
 
 const Home = () => {
   const dispatch = useDispatch();
@@ -18,15 +20,6 @@ const Home = () => {
       alert(retweetError);
     }
   }, [retweetError]);
-
-  useEffect(() => {
-    dispatch({
-      type: LOAD_MY_INFO_REQUEST,
-    });
-    dispatch({
-      type: LOAD_POSTS_REQUEST,
-    });
-  }, []);
 
   useEffect(() => {
     // comopnentDidMount()
@@ -58,6 +51,18 @@ const Home = () => {
     </AppLayout>
   );
 };
+
+export const getServerSideProps = wrapper.getServerSideProps((store) => async () => {
+  console.log('store', store);
+  store.dispatch({
+    type: LOAD_MY_INFO_REQUEST,
+  });
+  store.dispatch({
+    type: LOAD_POSTS_REQUEST,
+  });
+  store.dispatch(END);
+  await store.sagaTask.toPromise(); // store/configureStore.js > store.sagaTask
+}); // 이 부분이 Home 보다 먼저 실행됨
 
 export default Home;
 // $npm install next / $npm install next@9 [@version]

--- a/prepare/front/reducers/index.js
+++ b/prepare/front/reducers/index.js
@@ -7,22 +7,27 @@ import post from './post';
 // async action creator(비동기) / redux-saga
 
 // (이전상태, 액션) >> 다음 상태
-const rootReducer = combineReducers({
-  // HYDRATE를 위해 index reducer를 추가 (SSR을 위해 추가함)
-  index: (state = {}, action) => {
-    switch (action.type) {
-      case HYDRATE:
-        console.log('HYDRATE', action);
-        return {
-          ...state,
-          ...action.payload,
-        };
-      default:
-        return state;
+// HYDRATE를 위해 index reducer를 추가 (SSR을 위해 추가함)
+const rootReducer = (state, action) => {
+  switch (action.type) {
+    case HYDRATE:
+      console.log('HYDRATE', action);
+      return action.payload;
+    default: {
+      const combinedReducer = combineReducers({
+        user,
+        post,
+      });
+      return combinedReducer(state, action);
     }
-  },
-  user,
-  post,
-});
+  }
+};
 
 export default rootReducer;
+
+/* 이걸 확장 가능하게 구조화한 것이 위의 코드
+  const rootReducer = combineReducers({
+    user,
+    post,
+  }); 
+ */

--- a/prepare/front/store/configureStore.js
+++ b/prepare/front/store/configureStore.js
@@ -31,21 +31,8 @@ const configureStore = () => {
   return store;
 };
 // { debug: process.env.NODE_ENV === "development" }
-const wrapper = createWrapper(configureStore, { debug: true }); // 두번째는 옵션 객체
+const wrapper = createWrapper(configureStore, {
+  debug: process.env.NODE_ENV === 'development',
+}); // 두번째는 옵션 객체
 
 export default wrapper;
-
-//! reduxTools (no store found. make sure to follow the instructions.)
-// $npm i redux-devtools-extension
-
-//* redux-thunk
-// $npm install redux-thunk
-//! $npm rm redux-thunk (redux-thunk는 지워주자)
-
-/* npm install redux-saga
-* Redux-Saga
-! - Click이 여러번 발생해도 마직막 클릭만 요청을 보낸다
-! - 딜레이 되는 부분을 제공하여 편리하다
-! - Redux-Saga-throttle로 스크롤 시 수없이 가는 요청을 몇번 허용할지 제한이 가능하다
-! - Saga에서 제공하는 부분이 편리하므로 redux구현 시 복잡함에 따라 Saga 사용이 좋다
-*/


### PR DESCRIPTION
completed readyTo/SSR/Server-Side-Rendering

- 페이지가 시작될 때, FrontServer에서 데이터까지 한번에 받아올 수 있게 설정
- Home보다 먼저 실행되어 데이터를 미리 다 받아온다.
- 라이브러리 참고: https://github.com/kirill-konshin/next-redux-wrapper
- 구글링 방법: next redux-wrapper

> next 6버전을 사용하려 했으나 최신 버전인 7버전에 맞게 getServerSideProps를 사용

```javascript
// pages/index.js
import { END } from 'redux-saga';

export const getServerSideProps = wrapper.getServerSideProps((store) => async () => {
  console.log('store', store);
  store.dispatch({
    type: LOAD_MY_INFO_REQUEST,
  });
  store.dispatch({
    type: LOAD_POSTS_REQUEST,
  });
  store.dispatch(END);
  await store.sagaTask.toPromise(); // store/configureStore.js > store.sagaTask
}); // 이 부분이 Home 보다 먼저 실행됨
```

```javascript
// store/configureStore.js
const configureStore = () => {
  ...
  store.sagaTask = sagaMiddleware.run(rootSaga); // 이 부분을 pages/index.js에 가져다 사용
  ...
};
```

```javascript
// reducer/index.js
const rootReducer = (state, action) => {
  switch (action.type) {
    case HYDRATE:
      console.log('HYDRATE', action);
      return action.payload;
    default: {
      const combinedReducer = combineReducers({
        user,
        post,
      });
      return combinedReducer(state, action);
    }
  }
};
```