### PR TITLE
getStaticProps 사용해보기

### DIFF
--- a/prepare/back/routes/user.js
+++ b/prepare/back/routes/user.js
@@ -46,6 +46,45 @@ router.get('/', async (req, res, next) => {
   }
 }); // GET /user
 
+router.get('/:userId', async (req, res, next) => {
+  try {
+    const fullUserWithoutPassword = await User.findOne({
+      where: { id: req.params.userId },
+      attributes: {
+        exclude: ['password'], // 원하는 정보만 가져오거나 가져오지 않겠다 / 현재: pw 빼고 다 가져오겠다
+      },
+      include: [
+        {
+          model: Post,
+          attributes: ['id'],
+        },
+        {
+          model: User,
+          as: 'Followers',
+          attributes: ['id'],
+        },
+        {
+          model: User,
+          as: 'Followings',
+          attributes: ['id'],
+        },
+      ], // 가져올 정보중 뺄 것들
+    });
+    if (fullUserWithoutPassword) {
+      const data = fullUserWithoutPassword.toJSON();
+      data.Posts = data.Posts.length;
+      data.Followers = data.Followers.length;
+      data.Followings = data.Followings.length;
+      res.status(200).json(data);
+    } else {
+      res.status(404).send('존재하지 않는 사용자입니다.');
+    }
+  } catch (err) {
+    console.error(err);
+    next(err);
+  }
+}); // GET /user/1
+
 // err: 서버에러, user: 성공객체, info: 정보 // middleware 확장
 router.post('/login', isNotLoggedIn, (req, res, next) => {
   passport.authenticate('local', (err, user, info) => {

--- a/prepare/back/routes/user.js
+++ b/prepare/back/routes/user.js
@@ -72,7 +72,7 @@ router.get('/:userId', async (req, res, next) => {
     });
     if (fullUserWithoutPassword) {
       const data = fullUserWithoutPassword.toJSON();
-      data.Posts = data.Posts.length;
+      data.Posts = data.Posts.length; // 개인정보 침해 예방
       data.Followers = data.Followers.length;
       data.Followings = data.Followings.length;
       res.status(200).json(data);

--- a/prepare/front/pages/about.js
+++ b/prepare/front/pages/about.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import Head from 'next/head';
+import { END } from 'redux-saga';
+
+import { Card, Avatar } from 'antd';
+import AppLayout from '../components/AppLayout';
+import wrapper from '../store/configureStore';
+import { LOAD_USER_REQUEST } from '../reducers/user';
+
+const About = () => {
+  const { userInfo } = useSelector((state) => state.user);
+
+  return (
+    <>
+      <AppLayout>
+        <Head>
+          <title>내 프로필 | NodeBird</title>
+        </Head>
+        {userInfo ? (
+          <Card
+            actions={[
+              <div key="twit">
+                짹짹
+                <br />
+                {userInfo.Posts}
+              </div>,
+              <div key="following">
+                팔로잉
+                <br />
+                {userInfo.Followings}
+              </div>,
+              <div key="follower">
+                팔로워
+                <br />
+                {userInfo.Followers}
+              </div>,
+            ]}
+          >
+            <Card.Meta
+              avatar={<Avatar>{userInfo.nickname[0]}</Avatar>}
+              title={userInfo.nickname}
+              description="노드버드 매니아"
+            />
+          </Card>
+        ) : null}
+      </AppLayout>
+    </>
+  );
+};
+
+export const getStaticProps = wrapper.getStaticProps((store) => async () => {
+  console.log('getStaticProps');
+  store.dispatch({
+    type: LOAD_USER_REQUEST,
+    data: 1,
+  });
+  store.dispatch(END);
+  await store.sagaTask.toPromise();
+});
+
+export default About;

--- a/prepare/front/pages/index.js
+++ b/prepare/front/pages/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'; // next는 이 구문이 필요없다(써도 상관은 없다)
 import { useDispatch, useSelector } from 'react-redux';
 import { END } from 'redux-saga';
+import axios from 'axios';
 
 import AppLayout from '../components/AppLayout';
 import PostForm from '../components/PostForm';
@@ -9,7 +10,6 @@ import PostCard from '../components/PostCard';
 import { LOAD_POSTS_REQUEST } from '../reducers/post';
 import { LOAD_MY_INFO_REQUEST } from '../reducers/user';
 import wrapper from '../store/configureStore';
-import axios from 'axios';
 
 const Home = () => {
   const dispatch = useDispatch();
@@ -52,14 +52,13 @@ const Home = () => {
     </AppLayout>
   );
 };
-
+// try SSR with share cookie
 export const getServerSideProps = wrapper.getServerSideProps((store) => async ({ req }) => {
   const cookie = req ? req.headers.cookie : ''; // req가 있다면 cookie에 요청에 담겨진 cookie를 할당한다.
   axios.defaults.headers.Cookie = ''; // 요청이 들어올 때마다 초기화 시켜주는 것이다. 여기는 클라이언트 서버에서 실행되므로 이전 요청이 남아있을 수 있기 때문이다
   if (req && cookie) {
     axios.defaults.headers.Cookie = cookie; // 서버일때랑 cookie를 써서 요청을 보낼 때만 headers에 cookie를 넣어준다
   }
-  console.log('store', store);
   store.dispatch({
     type: LOAD_MY_INFO_REQUEST,
   });
@@ -74,5 +73,3 @@ export default Home;
 
 // $npm install next / $npm install next@9 [@version]
 // $npm install react react-dom
-
-//! getServerSideProps: cookie 공유 보안관련 아래는 중요한 부분, 나의 cookie가 다른 user와 공유가 되지 않게 해야한다. (AWS는 서버가 하나)

--- a/prepare/front/pages/profile.js
+++ b/prepare/front/pages/profile.js
@@ -2,20 +2,21 @@ import React, { useEffect } from 'react'; // next는 이 구문이 필요없다(
 import { useDispatch, useSelector } from 'react-redux';
 import Router from 'next/router';
 import Head from 'next/head';
+import axios from 'axios';
+import { END } from 'redux-saga';
 // Form을 만들 때 ReactForm 라이브러리를 사용하는 것이 좋다
 import AppLayout from '../components/AppLayout';
 import NicknameEditForm from '../components/NicknameEditForm';
 import FollowList from '../components/FollowList';
 import { LOAD_FOLLOWERS_REQUEST, LOAD_FOLLOWINGS_REQUEST, LOAD_MY_INFO_REQUEST } from '../reducers/user';
 
+import wrapper from '../store/configureStore';
+
 const Profile = () => {
   const dispatch = useDispatch();
   const { me } = useSelector((state) => state.user);
 
   useEffect(() => {
-    dispatch({
-      type: LOAD_MY_INFO_REQUEST,
-    });
     dispatch({
       type: LOAD_FOLLOWERS_REQUEST,
     });
@@ -46,5 +47,22 @@ const Profile = () => {
     </>
   );
 };
+
+// try SSR with share cookie
+export const getServerSideProps = wrapper.getServerSideProps((store) => async ({ req }) => {
+  console.log('getServerSideProps start');
+  console.log(req.headers);
+  const cookie = req ? req.headers.cookie : ''; // req가 있다면 cookie에 요청에 담겨진 cookie를 할당한다.
+  axios.defaults.headers.Cookie = ''; // 요청이 들어올 때마다 초기화 시켜주는 것이다. 여기는 클라이언트 서버에서 실행되므로 이전 요청이 남아있을 수 있기 때문이다
+  if (req && cookie) {
+    axios.defaults.headers.Cookie = cookie; // 서버일때랑 cookie를 써서 요청을 보낼 때만 headers에 cookie를 넣어준다
+  }
+  store.dispatch({
+    type: LOAD_MY_INFO_REQUEST,
+  });
+  store.dispatch(END);
+  console.log('getServerSideProps end');
+  await store.sagaTask.toPromise(); // store/configureStore.js > store.sagaTask
+}); // 이 부분이 Home 보다 먼저 실행됨
 
 export default Profile;

--- a/prepare/front/pages/signup.js
+++ b/prepare/front/pages/signup.js
@@ -1,12 +1,17 @@
 import React, { useCallback, useEffect, useState } from 'react'; // next는 이 구문이 필요없다(써도 상관은 없다)
+import { useDispatch, useSelector } from 'react-redux';
 import Head from 'next/head';
 import Router from 'next/router';
+import { END } from 'redux-saga';
+import axios from 'axios';
+
 import { Button, Checkbox, Form, Input } from 'antd';
 import styled from 'styled-components';
-import { useDispatch, useSelector } from 'react-redux';
-import { SIGN_UP_REQUEST } from '../reducers/user';
+
+import { SIGN_UP_REQUEST, LOAD_MY_INFO_REQUEST } from '../reducers/user';
 import AppLayout from '../components/AppLayout';
 import useInput from '../hooks/useInput'; //* customHook 적용하기
+import wrapper from '../store/configureStore';
 
 const Signup = () => {
   const dispatch = useDispatch();
@@ -118,6 +123,22 @@ const Signup = () => {
     </AppLayout>
   );
 };
+
+export const getServerSideProps = wrapper.getServerSideProps((store) => async ({ req }) => {
+  console.log('getServerSideProps start');
+  console.log(req.headers);
+  const cookie = req ? req.headers.cookie : ''; // req가 있다면 cookie에 요청에 담겨진 cookie를 할당한다.
+  axios.defaults.headers.Cookie = ''; // 요청이 들어올 때마다 초기화 시켜주는 것이다. 여기는 클라이언트 서버에서 실행되므로 이전 요청이 남아있을 수 있기 때문이다
+  if (req && cookie) {
+    axios.defaults.headers.Cookie = cookie; // 서버일때랑 cookie를 써서 요청을 보낼 때만 headers에 cookie를 넣어준다
+  }
+  store.dispatch({
+    type: LOAD_MY_INFO_REQUEST,
+  });
+  store.dispatch(END);
+  console.log('getServerSideProps end');
+  await store.sagaTask.toPromise(); // store/configureStore.js > store.sagaTask
+});
 
 export default Signup;
 


### PR DESCRIPTION
Feature28/using/get static props

- getStaticProps: 언제 접속해도 데이터가 바뀔 일이 없다면 사용, 서버에 무리가 적음 (html 한번에 제공)
- getServerSideProps: 접속한 상황에 따라 화면이 바뀌어야 되면 사용한다. (제일 많이 사용)

> 예시
```javascript
export const getStaticProps = wrapper.getStaticProps((store) => async () => {
  console.log('getStaticProps');
  store.dispatch({
    type: LOAD_USER_REQUEST,
    data: 1,
  });
  store.dispatch(END);
  await store.sagaTask.toPromise();
});
```

```javascript
// try SSR with share cookie
export const getServerSideProps = wrapper.getServerSideProps((store) => async ({ req }) => {
  console.log('getServerSideProps start');
  console.log(req.headers);
  const cookie = req ? req.headers.cookie : ''; // req가 있다면 cookie에 요청에 담겨진 cookie를 할당한다.
  axios.defaults.headers.Cookie = ''; // 요청이 들어올 때마다 초기화 시켜주는 것이다. 여기는 클라이언트 서버에서 실행되므로 이전 요청이 남아있을 수 있기 때문이다
  if (req && cookie) {
    axios.defaults.headers.Cookie = cookie; // 서버일때랑 cookie를 써서 요청을 보낼 때만 headers에 cookie를 넣어준다
  }
  store.dispatch({
    type: LOAD_MY_INFO_REQUEST,
  });
  store.dispatch(END);
  console.log('getServerSideProps end');
  await store.sagaTask.toPromise(); // store/configureStore.js > store.sagaTask
}); // 이 부분이 Home 보다 먼저 실행됨
```