### PR TITLE
CSS Server-Side-Rendering 하기

### DIFF
--- a/prepare/front/.babelrc
+++ b/prepare/front/.babelrc
@@ -1,4 +1,12 @@
 {
   "presets": ["next/babel"],
-  "plugins": ["babel-plugin-styled-components"]
+  "plugins": [
+    [
+      "babel-plugin-styled-components",
+      {
+        "ssr": true,
+        "displayName": true
+      }
+    ]
+  ]
 }

--- a/prepare/front/.eslintrc
+++ b/prepare/front/.eslintrc
@@ -31,7 +31,8 @@
     "no-unused-vars": "off",
     "no-param-reassign": "off", // immer 사용 시 draft 때문에 "off"
     "react/prop-types": "off",
-    "no-alert": "off"
+    "no-alert": "off",
+    "react/jsx-props-no-spreading": "off" // {...props} problem in front/pages/_document.js
   }
 }
 /* npm install --save-dev */

--- a/prepare/front/pages/_document.js
+++ b/prepare/front/pages/_document.js
@@ -1,0 +1,53 @@
+// styled-compnents를 SSR 하려면, _document.js 가 필요 (app.js 위에 document.js가 있다)
+import React from 'react';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
+
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const sheet = new ServerStyleSheet();
+    console.log(ctx.renderPage);
+    const originalRenderPage = ctx.renderPage;
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
+        }); // SSR 할 때
+      const initialProps = await Document.getInitialProps(ctx);
+
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } catch (err) {
+      console.error(err);
+    } finally {
+      sheet.seal();
+    }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <script src="https://polyfill.io/v3/polyfill.min.js?features=default%2Ces2015%2Ces2016%2Ces2017%2Ces2018%2Ces2019" />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+// 이걸 하면 app.js가 document.js로 감싸지면서 제일 위에 있는 html, head, body 까지 수정이 가능해진다
+// 여기서 SSR을 해야되는데 getInitalProps가 있다
+// getInitalProps: document나 app에서 쓰는 특수한 SSR method 이다
+
+//! IE에서 실행하면 document.js가 안돌아간다 해결 방법은? (하단에 Polyfill.io)
+//! nextScript 위에 script 추가, Polyfill.io > CREATE A POLYFILL BUNDLE > copy URL HTML after check default ~ es2019


### PR DESCRIPTION
completed CSS ServerSideRendering
```
front(root)/.babelrc 생성
```
> styled-components 를 ssr하게 설정 할 수 있다.
displayName: true는 개발모드에서 (개발자도구를 통해) component 이름을 보기 편하게 해준다.
```javascript
{
  "presets": ["next/babel"],
  "plugins": [
    [
      "babel-plugin-styled-components",
      {
        "ssr": true,
        "displayName": true
      }
    ]
  ]
}

```
![image](https://user-images.githubusercontent.com/61128538/144751623-3b1345be-8738-465b-a232-a2388fa55622.png)
```
$npm install babel-plugin-styled-components
```
![image](https://user-images.githubusercontent.com/61128538/144751659-60e06930-36aa-4c50-a317-34e34dc649ad.png)
> pages/_document.js 생성
> _document는 _app 다음에 실행되며, 공통적으로 활용할 head (Ex. 메타 태그)나 body 태그 안에 들어갈 내용들을 커스텀할때 사용한다.
```javascript
// styled-compnents를 SSR 하려면, _document.js 가 필요 (app.js 위에 document.js가 있다)
import React from 'react';
import Document, { Html, Head, Main, NextScript } from 'next/document';
import { ServerStyleSheet } from 'styled-components';

export default class MyDocument extends Document {
  static async getInitialProps(ctx) {
    const sheet = new ServerStyleSheet();
    console.log(ctx.renderPage);
    const originalRenderPage = ctx.renderPage;
    try {
      ctx.renderPage = () =>
        originalRenderPage({
          enhanApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
        }); // SSR 할 때
      const initialProps = await Document.getInitialProps(ctx);

      return {
        ...initialProps,
        styles: (
          <>
            {initialProps.styles}
            {sheet.getStyleElement()}
          </>
        ),
      };
    } catch (err) {
      console.error(err);
    } finally {
      sheet.seal();
    }
  }

  render() {
    return (
      <Html>
        <Head />
        <body>
          <Main />
          <script src="https://polyfill.io/v3/polyfill.min.js?features=default%2Ces2015%2Ces2016%2Ces2017%2Ces2018%2Ces2019" />
          <NextScript />
        </body>
      </Html>
    );
  }
}

// 이걸 하면 app.js가 document.js로 감싸지면서 제일 위에 있는 html, head, body 까지 수정이 가능해진다
// 여기서 SSR을 해야되는데 getInitalProps가 있다
// getInitalProps: document나 app에서 쓰는 특수한 SSR method 이다

//! IE에서 실행하면 document.js가 안돌아간다 해결 방법은? (하단에 Polyfill.io)
//! nextScript 위에 script 추가, Polyfill.io > CREATE A POLYFILL BUNDLE > copy URL HTML after check default ~ es2019

```