### PR TITLE
fix SSR

### DIFF
--- a/prepare/front/pages/index.js
+++ b/prepare/front/pages/index.js
@@ -60,10 +60,10 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
     axios.defaults.headers.Cookie = cookie; // 서버일때랑 cookie를 써서 요청을 보낼 때만 headers에 cookie를 넣어준다
   }
   store.dispatch({
-    type: LOAD_POSTS_REQUEST, // post
+    type: LOAD_MY_INFO_REQUEST, // user
   });
   store.dispatch({
-    type: LOAD_MY_INFO_REQUEST, // user
+    type: LOAD_POSTS_REQUEST, // post
   });
   store.dispatch(END);
   await store.sagaTask.toPromise(); // store/configureStore.js > store.sagaTask


### PR DESCRIPTION
```javascript
// pages/index.js
export const getServerSideProps = wrapper.getServerSideProps((store) => async ({ req }) => {
  const cookie = req ? req.headers.cookie : ''; // req가 있다면 cookie에 요청에 담겨진 cookie를 할당한다.
  axios.defaults.headers.Cookie = ''; // 요청이 들어올 때마다 초기화 시켜주는 것이다. 여기는 클라이언트 서버에서 실행되므로 이전 요청이 남아있을 수 있기 때문이다
  if (req && cookie) {
    axios.defaults.headers.Cookie = cookie; // 서버일때랑 cookie를 써서 요청을 보낼 때만 headers에 cookie를 넣어준다
  }
  store.dispatch({
    type: LOAD_MY_INFO_REQUEST, // user
  });
  store.dispatch({
    type: LOAD_POSTS_REQUEST, // post
  });
  store.dispatch(END);
  await store.sagaTask.toPromise(); // store/configureStore.js > store.sagaTask
}); // 이 부분이 Home 보다 먼저 실행됨
```