### PR TITLE
change a reducer/UPLOAD_IMAGE_SUCCESS

### DIFF
--- a/prepare/front/reducers/post.js
+++ b/prepare/front/reducers/post.js
@@ -128,7 +128,7 @@ const reducer = (state = initialState, action) =>
         draft.uploadImagesError = null;
         break;
       case UPLOAD_IMAGES_SUCCESS: {
-        draft.imagePaths = action.data;
+        draft.imagePaths = draft.imagePaths.concat(action.data);
         draft.uploadImagesLoading = false;
         draft.uploadImagesDone = true;
         break;


### PR DESCRIPTION
```javascript
// before /reducers/post.js
case UPLOAD_IMAGES_SUCCESS: {
        draft.imagePaths = action.data;
        draft.uploadImagesLoading = false;
        draft.uploadImagesDone = true;
        break;
      }
```
```javascript
// after /reducers/post.js
case UPLOAD_IMAGES_SUCCESS: {
        draft.imagePaths = draft.imagePaths.concat(action.data);
        draft.uploadImagesLoading = false;
        draft.uploadImagesDone = true;
        break;
      }
```